### PR TITLE
Disable failure's "backtrace" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/cookie_store"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-failure = "0.1.5"
+failure = { version = "0.1.5", default-features = false } # don't need backtrace
 failure_derive = "0.1.5"
 idna = "0.1.5"
 log = "0.4.6"


### PR DESCRIPTION
As was noticed in https://github.com/seanmonstar/reqwest/pull/480, seems the backtrace feature of Cargo doesn't easily compile on Android. Since it doesn't look like its ever needed in cookie_store (there's no `failure::Context::new()` calls), this will save pulling that dependency.