### PR TITLE
Revert "Disable failure's "backtrace" feature"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/cookie_store"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-failure = { version = "0.1.5", default-features = false } # don't need backtrace
+failure = "0.1.5"
 failure_derive = "0.1.5"
 idna = "0.1.5"
 log = "0.4.6"


### PR DESCRIPTION
Reverts pfernie/cookie_store#1

With the current feature set of `failure`, one cannot disable `backtrace` without disabling `std`, which also conditionally compiles out `failure::Error` which is used in this crate.