### PR TITLE
Use Rust's TryFrom trait instead of try_from crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ serde = "1.0.88"
 serde_derive = "1.0.88"
 serde_json = "1.0.38"
 time = "0.1.42"
-try_from = "0.3.2"
 url = "1.7.2"
 
 [dependencies.cookie]

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -5,11 +5,11 @@ use crate::cookie_path::CookiePath;
 use crate::utils::{is_http_scheme, is_secure};
 use ::cookie::{Cookie as RawCookie, CookieBuilder as RawCookieBuilder, ParseError};
 use serde_derive::{Deserialize, Serialize};
-use std::borrow::Cow;
-use std::ops::Deref;
 use std::{error, fmt};
+use std::borrow::Cow;
+use std::convert::TryFrom;
+use std::ops::Deref;
 use time;
-use try_from::TryFrom;
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/cookie_domain.rs
+++ b/src/cookie_domain.rs
@@ -1,10 +1,10 @@
 use std;
+use std::convert::TryFrom;
 
 use ::cookie::Cookie as RawCookie;
 use idna;
 use publicsuffix;
 use serde_derive::{Deserialize, Serialize};
-use try_from::TryFrom;
 use url::{Host, Url};
 
 use crate::utils::is_host_name;
@@ -125,8 +125,8 @@ impl CookieDomain {
 /// Construct a `CookieDomain::Suffix` from a string, stripping a single leading '.' if present.
 /// If the source string is empty, returns the `CookieDomain::Empty` variant.
 impl<'a> TryFrom<&'a str> for CookieDomain {
-    type Err = failure::Error;
-    fn try_from(value: &str) -> Result<CookieDomain, Self::Err> {
+    type Error = failure::Error;
+    fn try_from(value: &str) -> Result<CookieDomain, Self::Error> {
         idna::domain_to_ascii(value.trim())
             .map_err(super::IdnaErrors::from)
             .map_err(failure::Error::from)
@@ -149,8 +149,8 @@ impl<'a> TryFrom<&'a str> for CookieDomain {
 /// performing this step twice, the `From<&cookie::Cookie>` impl should be used,
 /// instead of passing `cookie.domain` to the `From<&str>` impl.
 impl<'a, 'c> TryFrom<&'a RawCookie<'c>> for CookieDomain {
-    type Err = failure::Error;
-    fn try_from(cookie: &'a RawCookie<'c>) -> Result<CookieDomain, Self::Err> {
+    type Error = failure::Error;
+    fn try_from(cookie: &'a RawCookie<'c>) -> Result<CookieDomain, Self::Error> {
         if let Some(domain) = cookie.domain() {
             idna::domain_to_ascii(domain.trim())
                 .map_err(super::IdnaErrors::from)
@@ -180,8 +180,8 @@ impl<'a> From<&'a CookieDomain> for String {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryFrom;
     use ::cookie::Cookie as RawCookie;
-    use try_from::TryFrom;
     use url::Url;
 
     use super::CookieDomain;
@@ -368,8 +368,8 @@ mod tests {
 mod serde {
     #[cfg(test)]
     mod tests {
+        use std::convert::TryFrom;
         use serde_json;
-        use try_from::TryFrom;
 
         use crate::cookie_domain::CookieDomain;
         use crate::utils::test::*;


### PR DESCRIPTION
Rust's `TryFrom` was stabilized in Rust 1.34.0.