### PR TITLE
Remove failure dependency in favor of std::error::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ documentation = "https://docs.rs/cookie_store"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-failure = "0.1.5"
 idna = "0.1.5"
 log = "0.4.6"
 publicsuffix = { version = "1.5.2", default-features = false }

--- a/src/cookie_domain.rs
+++ b/src/cookie_domain.rs
@@ -125,11 +125,11 @@ impl CookieDomain {
 /// Construct a `CookieDomain::Suffix` from a string, stripping a single leading '.' if present.
 /// If the source string is empty, returns the `CookieDomain::Empty` variant.
 impl<'a> TryFrom<&'a str> for CookieDomain {
-    type Err = failure::Error;
+    type Err = crate::Error;
     fn try_from(value: &str) -> Result<CookieDomain, Self::Err> {
         idna::domain_to_ascii(value.trim())
             .map_err(super::IdnaErrors::from)
-            .map_err(failure::Error::from)
+            .map_err(Into::into)
             .map(|domain| {
                 if domain.is_empty() || "." == domain {
                     CookieDomain::Empty
@@ -149,12 +149,12 @@ impl<'a> TryFrom<&'a str> for CookieDomain {
 /// performing this step twice, the `From<&cookie::Cookie>` impl should be used,
 /// instead of passing `cookie.domain` to the `From<&str>` impl.
 impl<'a, 'c> TryFrom<&'a RawCookie<'c>> for CookieDomain {
-    type Err = failure::Error;
+    type Err = crate::Error;
     fn try_from(cookie: &'a RawCookie<'c>) -> Result<CookieDomain, Self::Err> {
         if let Some(domain) = cookie.domain() {
             idna::domain_to_ascii(domain.trim())
                 .map_err(super::IdnaErrors::from)
-                .map_err(failure::Error::from)
+                .map_err(Into::into)
                 .map(|domain| {
                     if domain.is_empty() {
                         CookieDomain::Empty

--- a/src/cookie_store.rs
+++ b/src/cookie_store.rs
@@ -22,7 +22,7 @@ pub enum StoreAction {
     UpdatedExisting,
 }
 
-pub type StoreResult<T> = Result<T, failure::Error>;
+pub type StoreResult<T> = Result<T, crate::Error>;
 pub type InsertResult = Result<StoreAction, CookieError>;
 #[derive(Debug, Default)]
 pub struct CookieStore {
@@ -306,7 +306,7 @@ impl CookieStore {
     where
         W: Write,
         F: Fn(&Cookie<'static>) -> Result<String, E>,
-        failure::Error: From<E>,
+        crate::Error: From<E>,
     {
         for cookie in self.iter_unexpired().filter_map(|c| {
             if c.is_persistent() {
@@ -332,7 +332,7 @@ impl CookieStore {
     where
         R: BufRead,
         F: Fn(&str) -> Result<Cookie<'static>, E>,
-        failure::Error: From<E>,
+        crate::Error: From<E>,
     {
         let mut cookies = HashMap::new();
         for line in reader.lines() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use failure::Fail;
 use idna;
 
 mod cookie;
@@ -11,9 +10,16 @@ mod cookie_store;
 pub use crate::cookie_store::CookieStore;
 mod utils;
 
-#[derive(Debug, Fail)]
-#[fail(display = "IDNA errors: {:#?}", _0)]
+#[derive(Debug)]
 pub struct IdnaErrors(idna::uts46::Errors);
+
+impl std::fmt::Display for IdnaErrors {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "IDNA errors: {:#?}", self.0)
+    }
+}
+
+impl std::error::Error for IdnaErrors {}
 
 impl From<idna::uts46::Errors> for IdnaErrors {
     fn from(e: idna::uts46::Errors) -> Self {
@@ -21,4 +27,5 @@ impl From<idna::uts46::Errors> for IdnaErrors {
     }
 }
 
-pub type Result<T> = std::result::Result<T, failure::Error>;
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
This may be controversial, you may prefer the use of `failure`, but figured I'd try this. The failure crate has a so-far required dependency on `backtrace`, which can be problematic to compile on some targets (for example, see https://github.com/seanmonstar/reqwest/pull/554). Besides that, this just compiles less code.
 