### PR TITLE
Upgrade to url v2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ license = "MIT/Apache-2.0"
 [dependencies]
 idna = "0.1.5"
 log = "0.4.6"
-publicsuffix = { version = "1.5.2", default-features = false }
+publicsuffix = { version = "1.5.3", default-features = false }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 time = "0.1.42"
-url = "1.7.2"
+url = "2.0"
 
 [dependencies.cookie]
 features = ["percent-encode"]


### PR DESCRIPTION
I'm trying to upgrade reqwest to url 2.0, and it's proving to be quite the challenge. Upgrading cookie_store's version of url is one piece of the puzzle.

This PR is blocked on two upstream dependencies updating first:

  * [x] https://github.com/SergioBenitez/cookie-rs/pull/122
  * [x] https://github.com/rushmorem/publicsuffix/pull/19

For now, I've used a `[patch.crates-io]` block here in order to verify the change, but I'll remove that block as soon as the upstream PRs make it into their respective releases.