### PR TITLE
Disable reqwest's default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ time = "0.2.16"
 url = "2.1.1"
 
 indexmap = { version = "1.4.0", optional = true }
-reqwest = { version = "^0.11.2", optional = true, features = ["cookies"] }
+reqwest = { version = "^0.11.2", optional = true, default-features = false, features = ["cookies"] }
 bytes = { version = "1", optional = true }
 
 [dependencies.cookie]


### PR DESCRIPTION
Only the `cookies` feature seems necessary, and the other features may be undesirable, like `default-tls` (which conflicts with `rustls-tls`).

Strictly speaking this is a breaking change for depending packages that haven't declared all the features they use. Not sure if that warrants a minor version bump.