### PR TITLE
Secure cookies should always be attached to requests for localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+= v0.15.1 =
+* Attach `Secure` cookies to requests for `http://localhost`
+  
 = v0.15.0 =
 * deprecation in `v0.14.1` should have qualified as minor version bump
 * Upgrade dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 = v0.15.1 =
-* Attach `Secure` cookies to requests for `http://localhost`
+* Attach `Secure` cookies to requests for `http://localhost` and loopback IP addresses (e.g. `127.0.0.1`). This change aligns `cookie_store`'s behaviour to the behaviour of [Chromium-based browsers](https://bugs.chromium.org/p/chromium/issues/detail?id=1177877#c7) and [Firefox](https://hg.mozilla.org/integration/autoland/rev/c4d13b3ca1e2).
   
 = v0.15.0 =
 * deprecation in `v0.14.1` should have qualified as minor version bump

--- a/src/cookie_store.rs
+++ b/src/cookie_store.rs
@@ -1470,20 +1470,28 @@ mod tests {
     }
 
     #[test]
-    fn localhost_is_secure() {
-        let mut store = CookieStore::default();
-        inserted!(add_cookie(
-            &mut store,
-            "cookie1=1a; Secure",
-            "http://localhost/",
-            None,
-            None,
-        ));
-        matches_are(
-            &store,
-            "http://localhost/",
-            vec!["cookie1=1a"],
-        );
+    fn some_non_https_uris_are_secure() {
+        // Matching the list in Firefox's regression test:
+        // https://hg.mozilla.org/integration/autoland/rev/c4d13b3ca1e2
+        let secure_uris = vec![
+          "http://localhost", "http://localhost:1234", "http://127.0.0.1",
+          "http://127.0.0.2", "http://127.1.0.1",      "http://[::1]",
+        ];
+        for secure_uri in secure_uris {
+            let mut store = CookieStore::default();
+            inserted!(add_cookie(
+                &mut store,
+                "cookie1=1a; Secure",
+                secure_uri,
+                None,
+                None,
+            ));
+            matches_are(
+                &store,
+                secure_uri,
+                vec!["cookie1=1a"],
+            );
+        }
     }
 
     #[test]

--- a/src/cookie_store.rs
+++ b/src/cookie_store.rs
@@ -1470,6 +1470,23 @@ mod tests {
     }
 
     #[test]
+    fn localhost_is_secure() {
+        let mut store = CookieStore::default();
+        inserted!(add_cookie(
+            &mut store,
+            "cookie1=1a; Secure",
+            "http://localhost/",
+            None,
+            None,
+        ));
+        matches_are(
+            &store,
+            "http://localhost/",
+            vec!["cookie1=1a"],
+        );
+    }
+
+    #[test]
     fn domain_collisions() {
         let mut store = CookieStore::default();
         // - HostOnly, so no collisions here

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
-use url::ParseError as UrlError;
+use url::{ParseError as UrlError, Host};
 use url::Url;
 
 pub trait IntoUrl {
@@ -33,7 +33,18 @@ pub fn is_host_name(host: &str) -> bool {
 }
 
 pub fn is_secure(url: &Url) -> bool {
-    url.scheme() == "https" || url.host() == Some(url::Host::Domain("localhost"))
+    if url.scheme() == "https" {
+        return true;
+    }
+    if let Some(u) = url.host() {
+        match u {
+            Host::Domain(d) => d == "localhost",
+            Host::Ipv4(ip) => ip.is_loopback(),
+            Host::Ipv6(ip) => ip.is_loopback(),
+        }
+    } else {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,7 +33,7 @@ pub fn is_host_name(host: &str) -> bool {
 }
 
 pub fn is_secure(url: &Url) -> bool {
-    url.scheme() == "https"
+    url.scheme() == "https" || url.host() == Some(url::Host::Domain("localhost"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Even if the requests are performed over HTTP instead of HTTPS (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies).

I've added a regression test to cover this case.
The changelog has been updated as well.