### PR TITLE
Feature-gate `publicsuffix`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,16 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["public_suffix"]
 
 # uses `indexmap::IndexMap` in lieu of HashMap internally, so cookies are maintained in insertion/creation order
 preserve_order = ["indexmap"]
+public_suffix = ["publicsuffix"]
 
 [dependencies]
 idna = "0.2.3"
 log = "0.4.14"
-publicsuffix = "2.1.1"
+publicsuffix = { version = "2.1.1", optional = true }
 serde = { version = "1.0.136", features = [ "derive" ] }
 serde_json = "1.0.79"
 time = "0.3.7"

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -17,7 +17,7 @@ pub enum Error {
     /// Cookie had attribute HttpOnly but was received from a request-uri which was not an http
     /// scheme
     NonHttpScheme,
-    /// Cookie did not specify domain but was recevied from non-relative-scheme request-uri from
+    /// Cookie did not specify domain but was received from non-relative-scheme request-uri from
     /// which host could not be determined
     NonRelativeScheme,
     /// Cookie received from a request-uri that does not domain-match
@@ -26,6 +26,7 @@ pub enum Error {
     Expired,
     /// `cookie::Cookie` Parse error
     Parse,
+    #[cfg(feature = "public_suffix")]
     /// Cookie specified a public suffix domain-attribute that does not match the canonicalized
     /// request-uri host
     PublicSuffix,
@@ -49,6 +50,7 @@ impl fmt::Display for Error {
                 Error::DomainMismatch => "request-uri does not domain-match the cookie",
                 Error::Expired => "attempted to utilize an Expired Cookie",
                 Error::Parse => "unable to parse string as cookie::Cookie",
+                #[cfg(feature = "public_suffix")]
                 Error::PublicSuffix => "domain-attribute value is a public suffix",
                 Error::UnspecifiedDomain => "domain-attribute is not specified",
             }
@@ -196,7 +198,7 @@ impl<'a> Cookie<'a> {
             .and_then(|p| CookiePath::parse(p))
             .unwrap_or_else(|| CookiePath::default_path(request_url));
 
-        // per RFC6265, Max-Age takes precendence, then Expires, otherwise is Session
+        // per RFC6265, Max-Age takes precedence, then Expires, otherwise is Session
         // only
         let expires = if let Some(max_age) = raw_cookie.max_age() {
             CookieExpiration::from(max_age)

--- a/src/cookie_domain.rs
+++ b/src/cookie_domain.rs
@@ -2,6 +2,7 @@ use std;
 
 use cookie::Cookie as RawCookie;
 use idna;
+#[cfg(feature = "public_suffix")]
 use publicsuffix::{List, Psl, Suffix};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -95,6 +96,7 @@ impl CookieDomain {
 
     /// Tests if the domain-attribute is a public suffix as indicated by the provided
     /// `publicsuffix::List`.
+    #[cfg(feature = "public_suffix")]
     pub fn is_public_suffix(&self, psl: &List) -> bool {
         if let Some(domain) = self.as_cow().as_ref().map(|d| d.as_bytes()) {
             psl.suffix(domain)


### PR DESCRIPTION
`publicsuffix` is sometimes not needed. We can make it optional with a feature.