### PR TITLE
feat: make logging secure cookie values opt-in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ preserve_order = ["indexmap"]
 public_suffix = ["publicsuffix"]
 wasm-bindgen = ["time/wasm-bindgen"]
 
+# Enable logging the values of cookies marked 'secure', off by default as values may be sensitive
+log_secure_cookie_values = []
+
 [dependencies]
 idna = "0.3"
 log = "0.4.17"

--- a/src/cookie_store.rs
+++ b/src/cookie_store.rs
@@ -80,7 +80,12 @@ impl CookieStore {
         url: &Url,
     ) {
         for cookie in cookies {
-            debug!("inserting Set-Cookie '{:?}'", cookie);
+            if cookie.secure() != Some(true) || cfg!(feature = "log_secure_cookie_values") {
+                debug!("inserting Set-Cookie '{:?}'", cookie);
+            } else {
+                debug!("inserting secure cookie '{}'", cookie.name());
+            }
+
             if let Err(e) = self.insert_raw(&cookie, url) {
                 debug!("unable to store Set-Cookie: {:?}", e);
             }


### PR DESCRIPTION
* Add a feature flag for 'log_secure_cookie_values', and only logs the name of cookies marked 'secure' otherwise. This way people won't inadvertently leak potentially sensitive information like session tokens when setting the log level to debug.

Fixes https://github.com/pfernie/cookie_store/issues/29.

Went with the simple approach of just logging the name of secure cookies since that was easiest, with a feature flag for full logging if people actually need to debug a cookie store problem with secure cookies (at which point presumably they're aware that the values will end up in logs and can take steps to add a filter if they want).

Briefly considered doing something like cloning the secure cookie, setting the value to an empty string or "redacted" or something and then `debug`ging that to get the other fields for secure cookies by default (not sure how concerned you are about perf/number of allocations), logging all the fields individually (I guess brittle if they decide to add a new attribute, though it seems that hasn't happened since 2016), or making a PR to cookie-rs to make [`fmt_parameters`](https://github.com/SergioBenitez/cookie-rs/blob/master/src/lib.rs#L899) `pub` if just the name isn't sufficient.