### PR TITLE
cookie_store: add API to save all cookies

### DIFF
--- a/src/cookie_store.rs
+++ b/src/cookie_store.rs
@@ -384,6 +384,24 @@ impl CookieStore {
         self.save(writer, ::serde_json::to_string)
     }
 
+    /// Serialize all cookies in the store with `cookie_to_string` and write them to `writer`
+    pub fn save_all<W, E, F>(&self, writer: &mut W, cookie_to_string: F) -> StoreResult<()>
+    where
+        W: Write,
+        F: Fn(&Cookie<'static>) -> Result<String, E>,
+        crate::Error: From<E>,
+    {
+        for cookie in self.iter_any() {
+            writeln!(writer, "{}", cookie_to_string(cookie)?)?;
+        }
+        Ok(())
+    }
+
+    /// Serialize all cookies in the store to JSON format and write them to `writer`
+    pub fn save_all_json<W: Write>(&self, writer: &mut W) -> StoreResult<()> {
+        self.save_all(writer, ::serde_json::to_string)
+    }
+
     /// Load cookies from `reader`, deserializing with `cookie_from_str`, skipping any __expired__
     /// cookies
     pub fn load<R, E, F>(reader: R, cookie_from_str: F) -> StoreResult<CookieStore>


### PR DESCRIPTION
There are APIs to save unexpired or permament cookies but there are no APIs to save all cookies, even though there are also APIs load all cookies as well.

This adds the 2 missing functions: one generic writer save_all() and a save_all_json() variant.

Signed-off-by: Adrian Ratiu <adi@adirat.com>