### PR TITLE
cookie_store: derive clone for CookieStore

### DIFF
--- a/src/cookie_store.rs
+++ b/src/cookie_store.rs
@@ -41,7 +41,7 @@ pub enum StoreAction {
 pub type StoreResult<T> = Result<T, crate::Error>;
 pub type InsertResult = Result<StoreAction, CookieError>;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 /// An implementation for storing and retrieving [`Cookie`]s per the path and domain matching
 /// rules specified in [RFC6265](https://datatracker.ietf.org/doc/html/rfc6265).
 pub struct CookieStore {


### PR DESCRIPTION
Sometimes it's useful to clone a CookieStore, so
allow this by deriving Clone.

Signed-off-by: Adrian Ratiu <adi@adirat.com>