### PR TITLE
cookie_store: fix missing raw cookie elements

### DIFF
--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -220,6 +220,12 @@ impl<'a> Cookie<'a> {
         if let Some(same_site) = raw_cookie.same_site() {
             builder = builder.same_site(same_site);
         }
+        if let Some(path) = raw_cookie.path() {
+            builder = builder.path(path.to_owned());
+        }
+        if let CookieDomain::Suffix(ref d) = domain {
+            builder = builder.domain(d.to_owned());
+        }
 
         Ok(Cookie {
             raw_cookie: builder.finish(),
@@ -784,7 +790,7 @@ mod serde_tests {
                 None,
             ),
             json!({
-                "raw_cookie": "cookie2=value2",
+                "raw_cookie": "cookie2=value2; Domain=example.com",
                 "path": ["/foo", false],
                 "domain": { "Suffix": "example.com" },
                 "expires": "SessionEnd"
@@ -799,7 +805,7 @@ mod serde_tests {
                 None,
             ),
             json!({
-                "raw_cookie": "cookie3=value3",
+                "raw_cookie": "cookie3=value3; Path=/foo/bar",
                 "path": ["/foo/bar", true],
                 "domain": { "HostOnly": "foo.example.com" },
                 "expires": "SessionEnd",


### PR DESCRIPTION
Some raw cookie elements (domain & path) are lost
when adding a raw cookie to a cookie store, so
retrieving back the raw cookie from the store
results in information loss.

Fix this by ensuring the fields are added to the
raw cookie builder in try_from_raw_cookie().

We also fix two tests with the missing values.