### PR TITLE
Allow serde and serde_derive to compile in parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ log_secure_cookie_values = []
 idna = "0.3.0"
 log = "0.4.17"
 publicsuffix = { version = "2.2.3", optional = true }
-serde = { version = "1.0.147", features = [ "derive" ] }
+serde = "1.0.147"
+serde_derive = "1.0.147"
 serde_json = "1.0.87"
 time = "0.3.16"
 url = "2.3.1"

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -4,7 +4,7 @@ use crate::cookie_path::CookiePath;
 
 use crate::utils::{is_http_scheme, is_secure};
 use cookie::{Cookie as RawCookie, CookieBuilder as RawCookieBuilder, ParseError};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;

--- a/src/cookie_domain.rs
+++ b/src/cookie_domain.rs
@@ -4,7 +4,7 @@ use cookie::Cookie as RawCookie;
 use idna;
 #[cfg(feature = "public_suffix")]
 use publicsuffix::{List, Psl, Suffix};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use url::{Host, Url};
 

--- a/src/cookie_expiration.rs
+++ b/src/cookie_expiration.rs
@@ -1,6 +1,6 @@
 use std;
 
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use time::{self, OffsetDateTime};
 
 /// When a given `Cookie` expires

--- a/src/cookie_path.rs
+++ b/src/cookie_path.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::cmp::max;
 use std::ops::Deref;
 use url::Url;


### PR DESCRIPTION
Visualized in `cargo build --timings`:

| Before: | After: |
|---|---|
| <img src="https://github.com/pfernie/cookie_store/assets/1940490/4d1893b4-2fe5-446d-b88c-1f3fd751b482" width="350"> | <img src="https://github.com/pfernie/cookie_store/assets/1940490/47409b0d-3050-495c-8cf1-f486f8f1ab0a" width="350"> |

Previously `serde` and `serde_json` could only begin compiling after `serde_derive` was finished compiling. After, they can compile in parallel.

This reduces build time by 2 seconds (30%). This crate is in the critical path of the widely used `reqwest` crate, so I think this is worth doing.