### PR TITLE
Update `idna` and `cookie` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ wasm-bindgen = ["time/wasm-bindgen"]
 log_secure_cookie_values = []
 
 [dependencies]
-idna = "0.3.0"
+idna = "0.5.0"
 log = "0.4.17"
 publicsuffix = { version = "2.2.3", optional = true }
 serde = "1.0.147"
@@ -40,4 +40,4 @@ indexmap = { version = "2.0.0", optional = true }
 
 [dependencies.cookie]
 features = ["percent-encode"]
-version = "0.17.0"
+version = "0.18.0"

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -254,7 +254,7 @@ impl<'a> From<Cookie<'a>> for RawCookie<'a> {
             builder = builder.domain(s);
         }
 
-        builder.finish()
+        builder.build()
     }
 }
 


### PR DESCRIPTION
Hi there,

This PR brings the `idna` and `cookie` dependencies up-to-date, and replaces a call to the deprecated `CookieBuilder::finish` method with `CookieBuilder::build`.