### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serde_ron = ["serde", "dep:ron"]
 document-features = "0.2.10"
 idna = "1.0"
 log = "0.4.17"
-time = "0.3.16"
+time = "0.3.47"
 url = "2.3.1"
 
 indexmap = { version = "2.6.0", optional = true }


### PR DESCRIPTION
Bumps the dependency to at least 0.3.47 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2026-0009.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)